### PR TITLE
Add Chedraui shopping list custom integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Chedraui Shopping List Home Assistant Integration
+
+This repository provides a custom [Home Assistant](https://www.home-assistant.io/) integration that keeps a shopping list entity in sync with the online cart from [Chedraui México](https://www.chedraui.com.mx/).
+
+## Features
+
+- Config Flow based setup that authenticates with your Chedraui account.
+- Represents the current Chedraui cart as a Home Assistant to-do (shopping list) entity.
+- Supports adding, removing, and updating items directly from Home Assistant.
+- Synchronizes quantities including piece, weight, and volume based units.
+- Exposes helper services for programmatic workflows and product search.
+
+## Installation
+
+1. Copy the `custom_components/chedraui_shopping_list` directory into your Home Assistant `custom_components` folder.
+2. Restart Home Assistant.
+3. Add the integration from **Settings → Devices & Services → Add Integration → Chedraui Shopping List**.
+4. Provide your Chedraui credentials and (optionally) the store ID (defaults to `10151`).
+
+## Usage
+
+- A new to-do entity (shopping list) will appear. Items represent the content of your Chedraui cart.
+- Create items from the UI by entering either a product ID or name (the integration will search for matches). You can include quantity information in the description (e.g. `2 kg` or `3 piezas`).
+- Marking an item as completed removes it from the Chedraui cart.
+- Adjusting item details (quantity, unit) updates the remote cart accordingly.
+
+### Services
+
+The integration registers additional services under the `chedraui_shopping_list` domain:
+
+- `add_item`: Add a product to the cart using a known product ID.
+- `remove_item`: Remove a line item from the cart.
+- `update_item` / `set_quantity`: Modify quantity, unit, or weight for existing items.
+- `search_products`: Query the Chedraui catalog (supports service responses).
+
+Refer to `custom_components/chedraui_shopping_list/services.yaml` for the detailed field descriptions.
+
+## Disclaimer
+
+This integration relies on the public endpoints used by the Chedraui website. As the site evolves, the endpoints or authentication flow may change, requiring updates to the integration. Use responsibly and in accordance with the Chedraui terms of service.

--- a/custom_components/chedraui_shopping_list/__init__.py
+++ b/custom_components/chedraui_shopping_list/__init__.py
@@ -1,0 +1,225 @@
+"""The Chedraui Shopping List integration."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any, Callable
+
+from aiohttp import ClientError, ClientSession
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.typing import ConfigType
+import voluptuous as vol
+
+from .api import ChedrauiAuthError, ChedrauiClient, ChedrauiError
+from .const import (
+    CONF_STORE_ID,
+    DEFAULT_STORE_ID,
+    DOMAIN,
+    SERVICE_ADD_ITEM,
+    SERVICE_REMOVE_ITEM,
+    SERVICE_SEARCH_PRODUCTS,
+    SERVICE_SET_QUANTITY,
+    SERVICE_UPDATE_ITEM,
+)
+from .coordinator import ChedrauiDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[Platform] = [Platform.TODO]
+
+
+def _build_client(hass: HomeAssistant, entry: ConfigEntry) -> ChedrauiClient:
+    session: ClientSession = async_get_clientsession(hass)
+    store_id: str = entry.data.get(CONF_STORE_ID, DEFAULT_STORE_ID)
+    return ChedrauiClient(
+        session=session,
+        username=entry.data[CONF_USERNAME],
+        password=entry.data[CONF_PASSWORD],
+        store_id=store_id,
+    )
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Chedraui Shopping List integration from YAML."""
+    hass.data.setdefault(DOMAIN, {})
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up the Chedraui Shopping List config entry."""
+    client = _build_client(hass, entry)
+
+    try:
+        await client.async_login()
+    except ChedrauiAuthError as err:
+        raise ConfigEntryNotReady("Authentication failed") from err
+    except ClientError as err:
+        raise ConfigEntryNotReady("Unable to communicate with Chedraui") from err
+
+    coordinator = ChedrauiDataUpdateCoordinator(hass, client)
+
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except ChedrauiError as err:
+        raise ConfigEntryNotReady("Unable to fetch initial cart state") from err
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = IntegrationData(
+        client=client,
+        coordinator=coordinator,
+        service_unsubscribers=[],
+    )
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    _register_services(hass, entry)
+
+    entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
+
+    return True
+
+
+async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a Chedraui Shopping List config entry."""
+    if entry.entry_id not in hass.data.get(DOMAIN, {}):
+        return True
+
+    integration_data: IntegrationData = hass.data[DOMAIN][entry.entry_id]
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        for unsub in integration_data.service_unsubscribers:
+            unsub()
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok
+
+
+@dataclass
+class IntegrationData:
+    """Data for an active config entry."""
+
+    client: ChedrauiClient
+    coordinator: ChedrauiDataUpdateCoordinator
+    service_unsubscribers: list[Callable[[], None]]
+
+
+def _register_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    integration_data: IntegrationData = hass.data[DOMAIN][entry.entry_id]
+    client = integration_data.client
+    coordinator = integration_data.coordinator
+
+    async def handle_add(call: ServiceCall) -> None:
+        await client.async_add_to_cart(
+            product_id=str(call.data["product_id"]),
+            quantity=call.data.get("quantity", 1.0),
+            unit=call.data.get("unit"),
+            weight=call.data.get("weight"),
+            measurement_type=call.data.get("measurement_type"),
+        )
+        await coordinator.async_request_refresh()
+
+    async def handle_remove(call: ServiceCall) -> None:
+        await client.async_remove_from_cart(str(call.data["item_id"]))
+        await coordinator.async_request_refresh()
+
+    async def handle_update(call: ServiceCall) -> None:
+        await client.async_update_cart_item(
+            item_id=str(call.data["item_id"]),
+            quantity=call.data.get("quantity"),
+            unit=call.data.get("unit"),
+            weight=call.data.get("weight"),
+            measurement_type=call.data.get("measurement_type"),
+        )
+        await coordinator.async_request_refresh()
+
+    async def handle_set_quantity(call: ServiceCall) -> None:
+        await client.async_update_cart_item(
+            item_id=str(call.data["item_id"]),
+            quantity=call.data.get("quantity"),
+            unit=call.data.get("unit"),
+            weight=call.data.get("weight"),
+            measurement_type=call.data.get("measurement_type"),
+        )
+        await coordinator.async_request_refresh()
+
+    async def handle_search(call: ServiceCall) -> dict[str, Any]:
+        query = str(call.data["query"])
+        limit = call.data.get("limit", 10)
+        results = await client.async_search_products(query=query, limit=limit)
+        return {"results": [result.to_dict() for result in results]}
+
+    add_schema = vol.Schema(
+        {
+            vol.Required("product_id"): vol.Any(int, str),
+            vol.Optional("quantity", default=1.0): vol.Coerce(float),
+            vol.Optional("unit"): vol.Any(None, vol.Coerce(str)),
+            vol.Optional("measurement_type"): vol.Any(None, vol.Coerce(str)),
+            vol.Optional("weight"): vol.Coerce(float),
+        }
+    )
+    remove_schema = vol.Schema({vol.Required("item_id"): vol.Any(int, str)})
+    update_schema = vol.Schema(
+        {
+            vol.Required("item_id"): vol.Any(int, str),
+            vol.Optional("quantity"): vol.Coerce(float),
+            vol.Optional("unit"): vol.Any(None, vol.Coerce(str)),
+            vol.Optional("measurement_type"): vol.Any(None, vol.Coerce(str)),
+            vol.Optional("weight"): vol.Coerce(float),
+        }
+    )
+    search_schema = vol.Schema(
+        {
+            vol.Required("query"): vol.Coerce(str),
+            vol.Optional("limit", default=10): vol.All(int, vol.Range(min=1, max=50)),
+        }
+    )
+
+    integration_data.service_unsubscribers.append(
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_ADD_ITEM,
+            handle_add,
+            schema=add_schema,
+        )
+    )
+    integration_data.service_unsubscribers.append(
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_REMOVE_ITEM,
+            handle_remove,
+            schema=remove_schema,
+        )
+    )
+    integration_data.service_unsubscribers.append(
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_UPDATE_ITEM,
+            handle_update,
+            schema=update_schema,
+        )
+    )
+    integration_data.service_unsubscribers.append(
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SET_QUANTITY,
+            handle_set_quantity,
+            schema=update_schema,
+        )
+    )
+    integration_data.service_unsubscribers.append(
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SEARCH_PRODUCTS,
+            handle_search,
+            schema=search_schema,
+            supports_response=True,
+        )
+    )

--- a/custom_components/chedraui_shopping_list/api.py
+++ b/custom_components/chedraui_shopping_list/api.py
@@ -1,0 +1,534 @@
+"""Asynchronous client for interacting with Chedraui."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import logging
+import re
+from typing import Any, Iterable
+
+import async_timeout
+from aiohttp import ClientError, ClientResponse, ClientSession
+
+from .const import (
+    MEASUREMENT_TYPE_PIECE,
+    MEASUREMENT_TYPE_VOLUME,
+    MEASUREMENT_TYPE_WEIGHT,
+    UNIT_ALIASES,
+    UNIT_TO_MEASUREMENT_TYPE,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+LOGIN_PATH_TEMPLATE = "/wcs/resources/store/{store_id}/loginidentity"
+CART_PATH_TEMPLATE = "/wcs/resources/store/{store_id}/cart"
+CART_ITEM_PATH_TEMPLATE = "/wcs/resources/store/{store_id}/cart/@self/{item_id}"
+CART_SELF_PATH_TEMPLATE = "/wcs/resources/store/{store_id}/cart/@self"
+SEARCH_PATH_TEMPLATE = "/wcs/resources/store/{store_id}/productview/bySearchTerm/{query}"
+
+DEFAULT_HEADERS = {
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "User-Agent": "HomeAssistant/chedraui_shopping_list (+https://www.home-assistant.io/)",
+    "Accept-Language": "es-MX,es;q=0.9,en;q=0.8",
+}
+
+REQUEST_TIMEOUT = 30
+
+
+class ChedrauiError(Exception):
+    """Base exception for Chedraui errors."""
+
+
+class ChedrauiAuthError(ChedrauiError):
+    """Authentication error."""
+
+
+class ChedrauiRequestError(ChedrauiError):
+    """Raised when Chedraui returns an error response."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+@dataclass(slots=True)
+class CartItem:
+    """Representation of an item in the Chedraui cart."""
+
+    item_id: str
+    product_id: str
+    name: str
+    quantity: float
+    unit: str
+    measurement_type: str
+    price: float | None = None
+    original_payload: dict[str, Any] | None = None
+
+
+@dataclass(slots=True)
+class ProductSummary:
+    """Summary for a Chedraui product."""
+
+    product_id: str
+    sku: str | None
+    name: str
+    price: float | None
+    unit: str | None
+    measurement_type: str | None
+    category: str | None = None
+    brand: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "product_id": self.product_id,
+            "sku": self.sku,
+            "name": self.name,
+            "price": self.price,
+            "unit": self.unit,
+            "measurement_type": self.measurement_type,
+            "category": self.category,
+            "brand": self.brand,
+        }
+
+
+class ChedrauiClient:
+    """API client for interacting with the Chedraui store."""
+
+    base_url: str = "https://www.chedraui.com.mx"
+
+    def __init__(
+        self,
+        *,
+        session: ClientSession,
+        username: str,
+        password: str,
+        store_id: str,
+    ) -> None:
+        self._session = session
+        self._username = username
+        self._password = password
+        self._store_id = store_id
+        self._cookies: dict[str, str] = {}
+        self._is_authenticated = False
+        self.available_units = sorted({*UNIT_TO_MEASUREMENT_TYPE.keys()})
+        self.measurement_types = sorted(
+            {MEASUREMENT_TYPE_PIECE, MEASUREMENT_TYPE_WEIGHT, MEASUREMENT_TYPE_VOLUME}
+        )
+
+    async def async_login(self) -> None:
+        """Authenticate against the Chedraui platform."""
+        payload = {
+            "logonId": self._username,
+            "logonPassword": self._password,
+        }
+
+        response = await self._request(
+            "POST",
+            LOGIN_PATH_TEMPLATE.format(store_id=self._store_id),
+            json=payload,
+            allow_reauth=False,
+        )
+
+        if response is None:
+            raise ChedrauiAuthError("Unexpected empty authentication response")
+
+        self._is_authenticated = True
+
+    async def async_ensure_authenticated(self) -> None:
+        if not self._is_authenticated:
+            await self.async_login()
+
+    async def async_get_cart(self) -> list[CartItem]:
+        """Retrieve the current cart contents."""
+        await self.async_ensure_authenticated()
+        data = await self._request(
+            "GET",
+            CART_SELF_PATH_TEMPLATE.format(store_id=self._store_id),
+        )
+        return self._parse_cart_items(data)
+
+    async def async_add_to_cart(
+        self,
+        *,
+        product_id: str,
+        quantity: float = 1.0,
+        unit: str | None = None,
+        weight: float | None = None,
+        measurement_type: str | None = None,
+    ) -> CartItem:
+        await self.async_ensure_authenticated()
+
+        normalized_unit = self._normalize_unit(unit, measurement_type)
+        payload: dict[str, Any] = {
+            "orderItem": [
+                {
+                    "productId": str(product_id),
+                    "quantity": quantity,
+                }
+            ]
+        }
+
+        if normalized_unit:
+            payload["orderItem"][0]["uom"] = normalized_unit
+        if weight is not None:
+            payload["orderItem"][0]["weight"] = weight
+
+        data = await self._request(
+            "POST",
+            CART_PATH_TEMPLATE.format(store_id=self._store_id),
+            json=payload,
+        )
+
+        items = self._parse_cart_items(data)
+        if not items:
+            raise ChedrauiRequestError("Failed to add item to cart")
+        return items[-1]
+
+    async def async_update_cart_item(
+        self,
+        *,
+        item_id: str,
+        quantity: float | None = None,
+        unit: str | None = None,
+        weight: float | None = None,
+        measurement_type: str | None = None,
+    ) -> list[CartItem]:
+        await self.async_ensure_authenticated()
+
+        if quantity is None and unit is None and weight is None and measurement_type is None:
+            _LOGGER.debug("No update data provided for item %s", item_id)
+            return await self.async_get_cart()
+
+        normalized_unit = self._normalize_unit(unit, measurement_type)
+        payload: dict[str, Any] = {"orderItem": [{}]}
+        payload_item = payload["orderItem"][0]
+        payload_item["orderItemId"] = str(item_id)
+
+        if quantity is not None:
+            payload_item["quantity"] = quantity
+        if normalized_unit is not None:
+            payload_item["uom"] = normalized_unit
+        if weight is not None:
+            payload_item["weight"] = weight
+
+        data = await self._request(
+            "PUT",
+            CART_PATH_TEMPLATE.format(store_id=self._store_id),
+            json=payload,
+        )
+        return self._parse_cart_items(data)
+
+    async def async_remove_from_cart(self, item_id: str) -> None:
+        await self.async_ensure_authenticated()
+        await self._request(
+            "DELETE",
+            CART_ITEM_PATH_TEMPLATE.format(store_id=self._store_id, item_id=item_id),
+        )
+
+    async def async_search_products(
+        self, *, query: str, limit: int = 10
+    ) -> list[ProductSummary]:
+        await self.async_ensure_authenticated()
+        params = {
+            "pageSize": str(limit),
+            "responseFormat": "json",
+            "pageNumber": "1",
+            "searchType": "keyword",
+        }
+        path = SEARCH_PATH_TEMPLATE.format(store_id=self._store_id, query=query)
+        data = await self._request("GET", path, params=params)
+        return self._parse_search_results(data)
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: Any | None = None,
+        allow_reauth: bool = True,
+    ) -> Any:
+        url = f"{self.base_url}{path}"
+        headers = dict(DEFAULT_HEADERS)
+
+        async with async_timeout.timeout(REQUEST_TIMEOUT):
+            try:
+                response: ClientResponse
+                response = await self._session.request(
+                    method,
+                    url,
+                    params=params,
+                    json=json,
+                    headers=headers,
+                    cookies=self._cookies,
+                )
+            except ClientError as err:
+                raise ChedrauiRequestError(
+                    f"Error communicating with Chedraui: {err}"
+                ) from err
+
+        await self._update_cookies(response)
+
+        if response.status == 401 and allow_reauth:
+            self._is_authenticated = False
+            await self.async_login()
+            return await self._request(
+                method,
+                path,
+                params=params,
+                json=json,
+                allow_reauth=False,
+            )
+
+        if response.status >= 400:
+            content = await response.text()
+            _LOGGER.debug(
+                "Chedraui request failed: %s %s (status: %s, body: %s)",
+                method,
+                url,
+                response.status,
+                content,
+            )
+            if response.status == 401:
+                raise ChedrauiAuthError("Authentication to Chedraui failed")
+            raise ChedrauiRequestError(
+                f"Chedraui error ({response.status}) while requesting {path}",
+                status=response.status,
+            )
+
+        if response.content_type == "application/json":
+            return await response.json()
+
+        text = await response.text()
+        if not text:
+            return None
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            _LOGGER.debug("Received non-JSON response for %s %s: %s", method, path, text)
+            return text
+
+    async def _update_cookies(self, response: ClientResponse) -> None:
+        for name, morsel in response.cookies.items():
+            value = morsel.value
+            if value is None:
+                continue
+            self._cookies[name] = value
+
+    def _parse_cart_items(self, data: Any) -> list[CartItem]:
+        if not data:
+            return []
+
+        order_items: Iterable[dict[str, Any]] = []
+        if isinstance(data, dict):
+            order_items = data.get("orderItem") or data.get("orderItems") or []
+        elif isinstance(data, list):
+            order_items = data
+
+        items: list[CartItem] = []
+        for raw in order_items:
+            if raw is None:
+                continue
+            item_id = str(raw.get("orderItemId") or raw.get("id") or raw.get("itemId") or "")
+            product_id = str(
+                raw.get("productId")
+                or raw.get("catEntryId")
+                or raw.get("catalogEntryId")
+                or raw.get("productPartNumber")
+                or ""
+            )
+            if not item_id:
+                continue
+            name = self._extract_name(raw)
+            quantity = self._extract_float(raw.get("quantity"), default=1.0)
+            unit = self._extract_unit(raw)
+            measurement_type = UNIT_TO_MEASUREMENT_TYPE.get(unit, MEASUREMENT_TYPE_PIECE)
+            price = self._extract_float(
+                raw.get("price")
+                or raw.get("offerPrice")
+                or raw.get("unitPrice")
+                or raw.get("orderItemAmount"),
+                default=None,
+            )
+            items.append(
+                CartItem(
+                    item_id=item_id,
+                    product_id=product_id,
+                    name=name,
+                    quantity=quantity,
+                    unit=unit,
+                    measurement_type=measurement_type,
+                    price=price,
+                    original_payload=raw,
+                )
+            )
+        return items
+
+    def _extract_name(self, raw: dict[str, Any]) -> str:
+        for key in ("productName", "name", "description"):
+            value = raw.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return "Producto"
+
+    def _extract_unit(self, raw: dict[str, Any]) -> str:
+        for key in ("uom", "unitOfMeasure", "unit", "measure"):
+            value = raw.get(key)
+            if isinstance(value, str) and value:
+                normalized = UNIT_ALIASES.get(value.lower())
+                return normalized or value.upper()
+        measurement = raw.get("measurementUnit") or raw.get("measurement")
+        if isinstance(measurement, str) and measurement:
+            normalized = UNIT_ALIASES.get(measurement.lower())
+            if normalized:
+                return normalized
+        return "EA"
+
+    def _normalize_unit(
+        self, unit: str | None, measurement_type: str | None
+    ) -> str | None:
+        if unit is None and measurement_type is None:
+            return None
+
+        normalized_unit: str | None = None
+        if unit:
+            normalized_unit = UNIT_ALIASES.get(unit.lower(), unit.upper())
+        elif measurement_type:
+            normalized_unit = self._default_unit_for_measurement(measurement_type)
+
+        if normalized_unit is None:
+            return None
+
+        if normalized_unit not in UNIT_TO_MEASUREMENT_TYPE:
+            _LOGGER.debug("Unknown unit %s, falling back to piece", normalized_unit)
+            return UNIT_ALIASES.get("ea", "EA")
+        return normalized_unit
+
+    def _default_unit_for_measurement(self, measurement_type: str) -> str | None:
+        measurement_type = measurement_type.lower()
+        if measurement_type == MEASUREMENT_TYPE_PIECE:
+            return "EA"
+        if measurement_type == MEASUREMENT_TYPE_WEIGHT:
+            return "KGM"
+        if measurement_type == MEASUREMENT_TYPE_VOLUME:
+            return "LTR"
+        return None
+
+    def _extract_float(self, value: Any, *, default: float | None) -> float | None:
+        if value is None:
+            return default
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            cleaned = value.replace(",", ".")
+            try:
+                return float(cleaned)
+            except ValueError:
+                return default
+        return default
+
+    def _parse_search_results(self, data: Any) -> list[ProductSummary]:
+        if not data:
+            return []
+
+        raw_items: Iterable[dict[str, Any]]
+        if isinstance(data, dict):
+            if "catalogEntryView" in data:
+                raw_items = data["catalogEntryView"]
+            elif "product" in data and isinstance(data["product"], dict):
+                raw_items = data["product"].get("docs", [])
+            else:
+                raw_items = data.get("items", [])
+        elif isinstance(data, list):
+            raw_items = data
+        else:
+            return []
+
+        results: list[ProductSummary] = []
+        for raw in raw_items:
+            if raw is None:
+                continue
+            product_id = str(
+                raw.get("partNumber")
+                or raw.get("uniqueID")
+                or raw.get("productId")
+                or raw.get("id")
+                or ""
+            )
+            if not product_id:
+                continue
+            sku = str(raw.get("sku") or raw.get("partNumber") or product_id)
+            name = self._extract_search_name(raw)
+            price = self._extract_float(
+                raw.get("price")
+                or raw.get("offerPrice")
+                or raw.get("bestPrice")
+                or raw.get("unitPrice"),
+                default=None,
+            )
+            unit = self._extract_search_unit(raw)
+            measurement_type = (
+                UNIT_TO_MEASUREMENT_TYPE.get(unit)
+                if unit
+                else self._infer_measurement_type_from_name(name)
+            )
+            brand = raw.get("brand")
+            category = None
+            categories = raw.get("category") or raw.get("categoryPath")
+            if isinstance(categories, list) and categories:
+                category = categories[-1] if isinstance(categories[-1], str) else None
+            results.append(
+                ProductSummary(
+                    product_id=product_id,
+                    sku=sku,
+                    name=name,
+                    price=price,
+                    unit=unit,
+                    measurement_type=measurement_type,
+                    category=category,
+                    brand=brand,
+                )
+            )
+        return results
+
+    def _extract_search_name(self, raw: dict[str, Any]) -> str:
+        for key in ("name", "productName", "shortDescription", "description"):
+            value = raw.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return "Producto"
+
+    def _extract_search_unit(self, raw: dict[str, Any]) -> str | None:
+        for key in ("uom", "unitOfMeasure", "unit", "measure"):
+            value = raw.get(key)
+            if isinstance(value, str) and value:
+                normalized = UNIT_ALIASES.get(value.lower())
+                return normalized or value.upper()
+        unit_desc = raw.get("unitOfMeasureText") or raw.get("measurement")
+        if isinstance(unit_desc, str):
+            normalized = UNIT_ALIASES.get(unit_desc.lower())
+            if normalized:
+                return normalized
+        quantity_desc = raw.get("measurement") or raw.get("measure")
+        if isinstance(quantity_desc, str):
+            match = _UNIT_IN_TEXT_REGEX.search(quantity_desc)
+            if match:
+                unit = match.group("unit")
+                return UNIT_ALIASES.get(unit.lower(), unit.upper())
+        return None
+
+    def _infer_measurement_type_from_name(self, name: str) -> str | None:
+        match = _UNIT_IN_TEXT_REGEX.search(name)
+        if not match:
+            return None
+        unit = UNIT_ALIASES.get(match.group("unit").lower())
+        if not unit:
+            return None
+        return UNIT_TO_MEASUREMENT_TYPE.get(unit)
+
+
+_UNIT_IN_TEXT_REGEX = re.compile(
+    r"(?P<value>\d+(?:[\.,]\d+)?)\s*(?P<unit>[a-zA-Záéíóúñ]+)",
+    re.IGNORECASE,
+)

--- a/custom_components/chedraui_shopping_list/config_flow.py
+++ b/custom_components/chedraui_shopping_list/config_flow.py
@@ -1,0 +1,104 @@
+"""Config flow for the Chedraui Shopping List integration."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from .api import ChedrauiAuthError, ChedrauiClient, ChedrauiRequestError
+from .const import CONF_STORE_ID, DEFAULT_STORE_ID, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ChedrauiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for the integration."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        self._errors: dict[str, str] = {}
+
+    async def async_step_user(
+        self, user_input: Mapping[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        if user_input is None:
+            return self._show_form()
+
+        username = str(user_input[CONF_USERNAME]).strip()
+        password = str(user_input[CONF_PASSWORD])
+        store_id = str(user_input.get(CONF_STORE_ID, DEFAULT_STORE_ID))
+
+        try:
+            await self._async_validate(username, password, store_id)
+        except ChedrauiAuthError:
+            self._errors["base"] = "auth"
+            return self._show_form(user_input)
+        except ChedrauiRequestError:
+            self._errors["base"] = "cannot_connect"
+            return self._show_form(user_input)
+
+        await self.async_set_unique_id(username.lower())
+        self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(
+            title=f"Chedraui ({username})",
+            data={
+                CONF_USERNAME: username,
+                CONF_PASSWORD: password,
+                CONF_STORE_ID: store_id,
+            },
+        )
+
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> config_entries.FlowResult:
+        self.context["entry_id"] = entry_data["entry_id"]
+        return await self.async_step_user()
+
+    async def async_step_reauth_confirm(
+        self, user_input: Mapping[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        entry_id = self.context.get("entry_id")
+        if entry_id is None:
+            return self.async_abort(reason="unknown")
+        entry = self.hass.config_entries.async_get_entry(entry_id)
+        if entry is None:
+            return self.async_abort(reason="unknown")
+        if user_input is None:
+            user_input = {
+                CONF_USERNAME: entry.data[CONF_USERNAME],
+                CONF_PASSWORD: entry.data[CONF_PASSWORD],
+                CONF_STORE_ID: entry.data.get(CONF_STORE_ID, DEFAULT_STORE_ID),
+            }
+        return await self.async_step_user(user_input)
+
+    async def _async_validate(self, username: str, password: str, store_id: str) -> None:
+        session = self.hass.helpers.aiohttp_client.async_get_clientsession()
+        client = ChedrauiClient(
+            session=session,
+            username=username,
+            password=password,
+            store_id=store_id,
+        )
+        await client.async_login()
+
+    def _show_form(
+        self, user_input: Mapping[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        user_input = dict(user_input or {})
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_USERNAME, default=user_input.get(CONF_USERNAME, "")): str,
+                vol.Required(CONF_PASSWORD, default=user_input.get(CONF_PASSWORD, "")): str,
+                vol.Optional(
+                    CONF_STORE_ID,
+                    default=user_input.get(CONF_STORE_ID, DEFAULT_STORE_ID),
+                ): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="user", data_schema=data_schema, errors=self._errors
+        )

--- a/custom_components/chedraui_shopping_list/const.py
+++ b/custom_components/chedraui_shopping_list/const.py
@@ -1,0 +1,88 @@
+"""Constants for the Chedraui Shopping List integration."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+DOMAIN = "chedraui_shopping_list"
+
+CONF_STORE_ID = "store_id"
+
+DEFAULT_STORE_ID = "10151"
+DEFAULT_SCAN_INTERVAL = timedelta(minutes=10)
+
+SERVICE_ADD_ITEM = "add_item"
+SERVICE_REMOVE_ITEM = "remove_item"
+SERVICE_UPDATE_ITEM = "update_item"
+SERVICE_SET_QUANTITY = "set_quantity"
+SERVICE_SEARCH_PRODUCTS = "search_products"
+
+ATTR_QUANTITY = "quantity"
+ATTR_UNIT = "unit"
+ATTR_WEIGHT = "weight"
+ATTR_MEASUREMENT_TYPE = "measurement_type"
+
+PIECE_UNIT = "EA"
+WEIGHT_UNIT_KG = "KGM"
+WEIGHT_UNIT_G = "GRM"
+WEIGHT_UNIT_LB = "LBR"
+VOLUME_UNIT_L = "LTR"
+VOLUME_UNIT_ML = "MLT"
+
+MEASUREMENT_TYPE_PIECE = "piece"
+MEASUREMENT_TYPE_WEIGHT = "weight"
+MEASUREMENT_TYPE_VOLUME = "volume"
+
+SUPPORTED_MEASUREMENT_TYPES = {
+    MEASUREMENT_TYPE_PIECE,
+    MEASUREMENT_TYPE_WEIGHT,
+    MEASUREMENT_TYPE_VOLUME,
+}
+
+UNIT_ALIASES: dict[str, str] = {
+    "pieza": PIECE_UNIT,
+    "piezas": PIECE_UNIT,
+    "pz": PIECE_UNIT,
+    "pieza(s)": PIECE_UNIT,
+    "piece": PIECE_UNIT,
+    "pieces": PIECE_UNIT,
+    "ea": PIECE_UNIT,
+    "unit": PIECE_UNIT,
+    "units": PIECE_UNIT,
+    "unidad": PIECE_UNIT,
+    "unidades": PIECE_UNIT,
+    "kg": WEIGHT_UNIT_KG,
+    "kilogram": WEIGHT_UNIT_KG,
+    "kilograms": WEIGHT_UNIT_KG,
+    "kilogramo": WEIGHT_UNIT_KG,
+    "kilogramos": WEIGHT_UNIT_KG,
+    "kilo": WEIGHT_UNIT_KG,
+    "kilos": WEIGHT_UNIT_KG,
+    "g": WEIGHT_UNIT_G,
+    "gr": WEIGHT_UNIT_G,
+    "gram": WEIGHT_UNIT_G,
+    "grams": WEIGHT_UNIT_G,
+    "gramo": WEIGHT_UNIT_G,
+    "gramos": WEIGHT_UNIT_G,
+    "lb": WEIGHT_UNIT_LB,
+    "lbs": WEIGHT_UNIT_LB,
+    "pound": WEIGHT_UNIT_LB,
+    "pounds": WEIGHT_UNIT_LB,
+    "l": VOLUME_UNIT_L,
+    "lt": VOLUME_UNIT_L,
+    "liter": VOLUME_UNIT_L,
+    "liters": VOLUME_UNIT_L,
+    "litro": VOLUME_UNIT_L,
+    "litros": VOLUME_UNIT_L,
+    "ml": VOLUME_UNIT_ML,
+    "mililitro": VOLUME_UNIT_ML,
+    "mililitros": VOLUME_UNIT_ML,
+}
+
+UNIT_TO_MEASUREMENT_TYPE: dict[str, str] = {
+    PIECE_UNIT: MEASUREMENT_TYPE_PIECE,
+    WEIGHT_UNIT_KG: MEASUREMENT_TYPE_WEIGHT,
+    WEIGHT_UNIT_G: MEASUREMENT_TYPE_WEIGHT,
+    WEIGHT_UNIT_LB: MEASUREMENT_TYPE_WEIGHT,
+    VOLUME_UNIT_L: MEASUREMENT_TYPE_VOLUME,
+    VOLUME_UNIT_ML: MEASUREMENT_TYPE_VOLUME,
+}

--- a/custom_components/chedraui_shopping_list/coordinator.py
+++ b/custom_components/chedraui_shopping_list/coordinator.py
@@ -1,0 +1,29 @@
+"""Data update coordinator for the Chedraui Shopping List integration."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .api import CartItem, ChedrauiClient, ChedrauiError
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ChedrauiDataUpdateCoordinator(DataUpdateCoordinator[list[CartItem]]):
+    """Coordinator that retrieves the current cart items."""
+
+    def __init__(self, hass: HomeAssistant, client: ChedrauiClient) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN} cart",
+            update_interval=DEFAULT_SCAN_INTERVAL,
+        )
+        self._client = client
+
+    async def _async_update_data(self) -> list[CartItem]:
+        return await self._client.async_get_cart()

--- a/custom_components/chedraui_shopping_list/manifest.json
+++ b/custom_components/chedraui_shopping_list/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "chedraui_shopping_list",
+  "name": "Chedraui Shopping List",
+  "version": "0.1.0",
+  "documentation": "https://example.com",
+  "issue_tracker": "https://example.com/issues",
+  "requirements": [],
+  "dependencies": [],
+  "codeowners": ["@your-github-handle"],
+  "iot_class": "cloud_polling",
+  "integration_type": "hub",
+  "loggers": ["custom_components.chedraui_shopping_list"]
+}

--- a/custom_components/chedraui_shopping_list/services.yaml
+++ b/custom_components/chedraui_shopping_list/services.yaml
@@ -1,0 +1,104 @@
+# Describes the services provided by the Chedraui Shopping List integration.
+add_item:
+  name: Add product to cart
+  description: Add a specific product to the authenticated Chedraui cart.
+  fields:
+    product_id:
+      name: Product ID
+      description: Unique identifier of the product (e.g. part number).
+      required: true
+      example: "7501234567890"
+    quantity:
+      name: Quantity
+      description: Quantity to add. Defaults to 1.
+      required: false
+      example: 2
+    unit:
+      name: Unit
+      description: Measurement unit code (EA, KGM, GRM, LTR, MLT...).
+      required: false
+      example: "KGM"
+    measurement_type:
+      name: Measurement type
+      description: Type of measurement (piece, weight, volume). Used if unit is omitted.
+      required: false
+      example: "weight"
+    weight:
+      name: Weight override
+      description: Optional weight in kilograms when required by the product.
+      required: false
+      example: 1.25
+
+remove_item:
+  name: Remove product from cart
+  description: Remove a line item from the cart by its order item identifier.
+  fields:
+    item_id:
+      name: Item ID
+      description: Identifier of the cart line item.
+      required: true
+      example: "123456"
+
+update_item:
+  name: Update a cart item
+  description: Update quantity or unit for an existing cart line item.
+  fields:
+    item_id:
+      name: Item ID
+      description: Identifier of the cart line item.
+      required: true
+    quantity:
+      name: Quantity
+      description: New quantity value.
+      required: false
+    unit:
+      name: Unit
+      description: Measurement unit code (EA, KGM, GRM, LTR, MLT...).
+      required: false
+    measurement_type:
+      name: Measurement type
+      description: Type of measurement (piece, weight, volume). Used if unit is omitted.
+      required: false
+    weight:
+      name: Weight override
+      description: Optional weight in kilograms.
+      required: false
+
+set_quantity:
+  name: Set the quantity for a cart item
+  description: Convenience service that sets the quantity for an existing cart line item.
+  fields:
+    item_id:
+      name: Item ID
+      description: Identifier of the cart line item.
+      required: true
+    quantity:
+      name: Quantity
+      description: New quantity value.
+      required: true
+    unit:
+      name: Unit
+      description: Measurement unit code (EA, KGM, GRM, LTR, MLT...).
+      required: false
+    measurement_type:
+      name: Measurement type
+      description: Type of measurement (piece, weight, volume). Used if unit is omitted.
+      required: false
+    weight:
+      name: Weight override
+      description: Optional weight in kilograms.
+      required: false
+
+search_products:
+  name: Search products
+  description: Search for products and return a structured response.
+  fields:
+    query:
+      name: Query
+      description: Free text to search in the Chedraui catalog.
+      required: true
+    limit:
+      name: Limit
+      description: Maximum number of products to return (1-50).
+      required: false
+      example: 10

--- a/custom_components/chedraui_shopping_list/strings.json
+++ b/custom_components/chedraui_shopping_list/strings.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Chedraui",
+        "description": "Authenticate with your Chedraui account to synchronize your shopping cart.",
+        "data": {
+          "username": "Email",
+          "password": "Password",
+          "store_id": "Store ID"
+        }
+      }
+    },
+    "error": {
+      "auth": "Invalid credentials",
+      "cannot_connect": "Cannot connect to Chedraui"
+    }
+  }
+}

--- a/custom_components/chedraui_shopping_list/todo.py
+++ b/custom_components/chedraui_shopping_list/todo.py
@@ -1,0 +1,253 @@
+"""Todo platform implementation for the Chedraui Shopping List."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import re
+from typing import Any, Iterable
+
+from homeassistant.components.todo import (
+    TodoItem,
+    TodoItemStatus,
+    TodoListEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .api import CartItem, ChedrauiClient
+from .const import (
+    ATTR_MEASUREMENT_TYPE,
+    ATTR_QUANTITY,
+    ATTR_UNIT,
+    DOMAIN,
+    UNIT_ALIASES,
+    UNIT_TO_MEASUREMENT_TYPE,
+)
+from .coordinator import ChedrauiDataUpdateCoordinator
+from . import IntegrationData
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    data: IntegrationData = hass.data[DOMAIN][entry.entry_id]
+    client: ChedrauiClient = data.client
+    coordinator: ChedrauiDataUpdateCoordinator = data.coordinator
+
+    async_add_entities([ChedrauiShoppingListEntity(entry, client, coordinator)])
+
+
+class ChedrauiShoppingListEntity(
+    CoordinatorEntity[ChedrauiDataUpdateCoordinator], TodoListEntity
+):
+    """Representation of the Chedraui shopping cart as a todo list."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Shopping List"
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        client: ChedrauiClient,
+        coordinator: ChedrauiDataUpdateCoordinator,
+    ) -> None:
+        super().__init__(coordinator)
+        self._client = client
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_shopping_list"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            manufacturer="Chedraui",
+            name="Chedraui Shopping Cart",
+        )
+
+    @property
+    def available(self) -> bool:
+        return super().available and bool(self.coordinator.last_update_success)
+
+    async def async_get_items(self) -> list[TodoItem]:
+        items: Iterable[CartItem] = self.coordinator.data or []
+        return [self._cart_item_to_todo(item) for item in items]
+
+    async def async_create_todo_item(self, item: TodoItem) -> TodoItem:
+        product_id: str | None = None
+        quantity: float = 1.0
+        unit: str | None = None
+        measurement_type: str | None = None
+
+        if item.extra:
+            product_id = _normalize_str(item.extra.get("product_id"))
+            unit = self._normalize_unit(item.extra.get(ATTR_UNIT))
+            measurement_type = _normalize_str(item.extra.get(ATTR_MEASUREMENT_TYPE))
+            extra_quantity = _coerce_float(item.extra.get(ATTR_QUANTITY), default=None)
+            if extra_quantity is not None:
+                quantity = extra_quantity
+
+        if item.description:
+            parsed = _parse_text(item.description)
+            quantity = parsed.quantity or quantity
+            unit = parsed.unit or unit
+            measurement_type = parsed.measurement_type or measurement_type
+            if parsed.product_id:
+                product_id = parsed.product_id
+
+        if product_id is None:
+            product_id = await self._resolve_product_id(item.summary)
+            if product_id is None:
+                raise ValueError("Unable to find product for item")
+
+        created = await self._client.async_add_to_cart(
+            product_id=product_id,
+            quantity=quantity,
+            unit=unit,
+            measurement_type=measurement_type,
+        )
+        await self.coordinator.async_request_refresh()
+        return self._cart_item_to_todo(created)
+
+    async def async_update_todo_item(self, item: TodoItem) -> TodoItem:
+        if item.uid is None:
+            raise ValueError("Todo item UID is required")
+
+        if item.status == TodoItemStatus.COMPLETED:
+            await self._client.async_remove_from_cart(item.uid)
+            await self.coordinator.async_request_refresh()
+            return item
+
+        quantity: float | None = None
+        unit: str | None = None
+        measurement_type: str | None = None
+
+        if item.extra:
+            quantity = _coerce_float(item.extra.get(ATTR_QUANTITY), default=None)
+            unit = self._normalize_unit(item.extra.get(ATTR_UNIT))
+            measurement_type = _normalize_str(item.extra.get(ATTR_MEASUREMENT_TYPE))
+
+        if item.description:
+            parsed = _parse_text(item.description)
+            quantity = parsed.quantity or quantity
+            unit = parsed.unit or unit
+            measurement_type = parsed.measurement_type or measurement_type
+
+        await self._client.async_update_cart_item(
+            item_id=item.uid,
+            quantity=quantity,
+            unit=unit,
+            measurement_type=measurement_type,
+        )
+        await self.coordinator.async_request_refresh()
+        refreshed = next(
+            (i for i in self.coordinator.data or [] if i.item_id == item.uid),
+            None,
+        )
+        return self._cart_item_to_todo(refreshed) if refreshed else item
+
+    async def async_delete_todo_item(self, uid: str) -> None:
+        await self._client.async_remove_from_cart(uid)
+        await self.coordinator.async_request_refresh()
+
+    async def _resolve_product_id(self, summary: str) -> str | None:
+        summary = summary.strip()
+        if not summary:
+            return None
+        if summary.isdigit():
+            return summary
+        results = await self._client.async_search_products(query=summary, limit=1)
+        if not results:
+            _LOGGER.warning("No products found for '%s'", summary)
+            return None
+        return results[0].product_id
+
+    def _cart_item_to_todo(self, item: CartItem | None) -> TodoItem:
+        if item is None:
+            return TodoItem(summary="", status=TodoItemStatus.NEEDS_ACTION)
+        description = (
+            f"Cantidad: {item.quantity} {item.unit}"
+            if item.unit
+            else f"Cantidad: {item.quantity}"
+        )
+        extra = {
+            "product_id": item.product_id,
+            ATTR_QUANTITY: item.quantity,
+            ATTR_UNIT: item.unit,
+            ATTR_MEASUREMENT_TYPE: item.measurement_type,
+        }
+        return TodoItem(
+            summary=item.name,
+            uid=item.item_id,
+            status=TodoItemStatus.NEEDS_ACTION,
+            description=description,
+            extra=extra,
+        )
+
+    def _normalize_unit(self, unit: Any | None) -> str | None:
+        if unit is None:
+            return None
+        if isinstance(unit, str) and unit:
+            return UNIT_ALIASES.get(unit.lower(), unit.upper())
+        return None
+
+
+@dataclass
+class ParsedText:
+    quantity: float | None
+    unit: str | None
+    measurement_type: str | None
+    product_id: str | None
+
+
+def _parse_text(text: str) -> ParsedText:
+    quantity: float | None = None
+    unit: str | None = None
+    measurement_type: str | None = None
+    product_id: str | None = None
+
+    match = _DESCRIPTION_REGEX.search(text)
+    if match:
+        quantity = _coerce_float(match.group("quantity"), default=None)
+        unit_text = match.group("unit")
+        if unit_text:
+            unit = UNIT_ALIASES.get(unit_text.lower(), unit_text.upper())
+            measurement_type = UNIT_TO_MEASUREMENT_TYPE.get(unit)
+
+    product_match = _PRODUCT_ID_REGEX.search(text)
+    if product_match:
+        product_id = product_match.group("product_id")
+
+    return ParsedText(quantity, unit, measurement_type, product_id)
+
+
+def _coerce_float(value: Any, *, default: float | None) -> float | None:
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.replace(",", "."))
+        except ValueError:
+            return default
+    return default
+
+
+def _normalize_str(value: Any | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str) and value:
+        return value.strip()
+    return None
+
+
+_DESCRIPTION_REGEX = re.compile(
+    r"(?P<quantity>\d+(?:[\.,]\d+)?)\s*(?P<unit>[a-zA-Záéíóúñ]+)",
+    re.IGNORECASE,
+)
+
+_PRODUCT_ID_REGEX = re.compile(r"product_id\s*[:=]\s*(?P<product_id>\w+)", re.IGNORECASE)

--- a/custom_components/chedraui_shopping_list/translations/en.json
+++ b/custom_components/chedraui_shopping_list/translations/en.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Chedraui",
+        "description": "Authenticate with your Chedraui account to synchronize your shopping cart.",
+        "data": {
+          "username": "Email",
+          "password": "Password",
+          "store_id": "Store ID"
+        }
+      }
+    },
+    "error": {
+      "auth": "Invalid credentials",
+      "cannot_connect": "Cannot connect to Chedraui"
+    }
+  }
+}

--- a/custom_components/chedraui_shopping_list/translations/es.json
+++ b/custom_components/chedraui_shopping_list/translations/es.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Conectar con Chedraui",
+        "description": "Autentica tu cuenta de Chedraui para sincronizar el carrito de compras.",
+        "data": {
+          "username": "Correo electrónico",
+          "password": "Contraseña",
+          "store_id": "ID de tienda"
+        }
+      }
+    },
+    "error": {
+      "auth": "Credenciales inválidas",
+      "cannot_connect": "No se pudo conectar con Chedraui"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Home Assistant custom integration that mirrors the Chedraui cart as a to-do based shopping list
- implement authentication, cart management, product search, and Home Assistant services for advanced workflows
- include configuration flow, translations, documentation, and service descriptions for installation and usage

## Testing
- python -m compileall custom_components/chedraui_shopping_list

------
https://chatgpt.com/codex/tasks/task_e_68cd8a56fa548327af56b39fbaff0da3